### PR TITLE
Added Chronic import to default theme

### DIFF
--- a/lib/to_spreadsheet/themes/default.rb
+++ b/lib/to_spreadsheet/themes/default.rb
@@ -1,3 +1,5 @@
+require 'chronic'
+
 module ToSpreadsheet::Themes
   module Default
     ::ToSpreadsheet.theme :default do


### PR DESCRIPTION
When a `datetime` or `time` field is parsed, a `uninitialized constant ToSpreadsheet::Themes::Default::Chronic` error is thrown. This should fix that problem.

I have verified this in my own branch and it works as expected.