### PR TITLE
Compatibility with Rails >= 6; Fix RDoc deprecation warning

### DIFF
--- a/lib/to_spreadsheet/rails/action_pack_renderers.rb
+++ b/lib/to_spreadsheet/rails/action_pack_renderers.rb
@@ -17,7 +17,7 @@ end
 ActionController::Renderers.add ToSpreadsheet.renderer do |template, options|
   filename = options[:filename] || options[:template] || 'data'
   data = ToSpreadsheet::Context.with_context ToSpreadsheet::Context.global.merge(ToSpreadsheet::Context.new) do |context|
-    html = render_to_string(template, options.merge(template: template.to_s, formats: ['xlsx', 'html']))
+    html = render_to_string(template, options.merge(template: template.to_s, formats: [:xlsx, :html]))
     ToSpreadsheet::Renderer.to_data(html, context)
   end
   send_data data, type: ToSpreadsheet.renderer, disposition: %(attachment; filename="#{filename}.xlsx")

--- a/to_spreadsheet.gemspec
+++ b/to_spreadsheet.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.files             = include_files - exclude_files
   s.require_path      = "lib"
   s.test_files        = Dir["spec/**/*_spec.rb"]
-  s.has_rdoc          = true
   s.extra_rdoc_files  = Dir["README*"]
   s.add_dependency 'rails'
   s.add_dependency 'nokogiri'


### PR DESCRIPTION
This PR fixes a [compatibility issue with Rails 6.0](https://github.com/glebm/to_spreadsheet/issues/35) (and also fixes a RDoc deprecation warning).  

Note: Also works with Rails 5