### PR TITLE
Switch to caxlsx

### DIFF
--- a/lib/to_spreadsheet/version.rb
+++ b/lib/to_spreadsheet/version.rb
@@ -1,3 +1,3 @@
 module ToSpreadsheet
-  VERSION = '1.0.7'
+  VERSION = '1.1.0'
 end

--- a/to_spreadsheet.gemspec
+++ b/to_spreadsheet.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = Dir["README*"]
   s.add_dependency 'rails'
   s.add_dependency 'nokogiri'
-  s.add_dependency 'axlsx'
+  s.add_dependency 'caxlsx'
   s.add_dependency 'chronic'
   s.add_dependency 'responders'
   s.add_development_dependency 'haml-rails'


### PR DESCRIPTION
axlsx is abandoned and dependent on rubyzip < 1.3 with vulnerabilities.
There's a community fork https://github.com/caxlsx/caxlsx without breaking changes.